### PR TITLE
Region::default will check env var and aws-config file

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ fn upload_file(
     let mut image_file = File::open(image_path)?;
     let mut content = Vec::new();
     image_file.read_to_end(&mut content)?;
-    let s3_client = S3Client::new(Region::UsEast2);
+    let s3_client = S3Client::new(Region::default());
     let put_request = PutObjectRequest {
         bucket: String::from("myglasseye.studio.photos"),
         key: event_name.to_string(),


### PR DESCRIPTION
https://github.com/rusoto/rusoto/blob/master/rusoto/core/src/region.rs#L19
```
/// `Region` implements the `Default` trait. Calling `Region::default()` will attempt to read the
/// `AWS_DEFAULT_REGION` or `AWS_REGION` environment variable. If it is malformed, it will fall back to `Region::UsEast1`.
/// If it is not present it will fallback on the value associated with the current profile in `~/.aws/config` or the file
/// specified by the `AWS_CONFIG_FILE` environment variable. If that is malformed of absent it will fall back on `Region::UsEast1`
///
```